### PR TITLE
Allow key absence (implement option deserialization)

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -232,11 +232,11 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
         Err(Error::UnsupportedType)
     }
 
-    fn deserialize_option<V>(self, _visitor: V) -> std::prelude::v1::Result<V::Value, Self::Error>
+    fn deserialize_option<V>(self, visitor: V) -> std::prelude::v1::Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        Err(Error::UnsupportedType)
+        visitor.visit_some(self)
     }
 
     fn deserialize_unit<V>(self, _visitor: V) -> std::prelude::v1::Result<V::Value, Self::Error>

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -94,7 +94,7 @@ impl<'a> serde::ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_none(self) -> std::prelude::v1::Result<Self::Ok, Self::Error> {
-        Err(Error::UnsupportedType)
+        Ok(())
     }
 
     fn serialize_some<T: ?Sized>(self, value: &T) -> std::prelude::v1::Result<Self::Ok, Self::Error>


### PR DESCRIPTION
hiii again!

"C:\Program Files (x86)\Steam\userdata\userid\760\screenshots.vdf" has some optional values:

```rs
#[derive(Serialize, Deserialize, Debug)]
struct ScreenshotOptionals {
    externalfilename: Option<String>,
    taggedpublishedfiles: Option<TaggedPublishedFiles>,
    caption: Option<String>,
    publishedfileid: Option<String>,
    timelineid: Option<String>,
    timelinetime: Option<String>,
}

#[derive(Serialize, Deserialize, Debug)]
struct TaggedPublishedFiles(HashMap<String, String>);
```